### PR TITLE
Update meeting time and cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A repository for team discussion, syncing, and meeting notes.
 
 ## [Weekly Team Meetings](https://github.com/jupyter-widgets/team-compass/issues/1)
 
-Developer Meetings take place on [zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09), on Tuesdays at 8:30AM Pacific Time ([your time](https://www.thetimezoneconverter.com/?t=8%3A30%20am&tz=San%20Francisco)).
+Developer Meetings take place on [zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09), every other Tuesday ([calendar](https://jupyter.org/community#calendar)) at 8:15AM Pacific Time ([your time](https://www.thetimezoneconverter.com/?t=8%3A30%20am&tz=San%20Francisco)).
 
 Minutes are taken at [Hackmd.io](https://hackmd.io/5XWHyOoLTRqyXzEHsVmxXg).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repository for team discussion, syncing, and meeting notes.
 
-## [Weekly Team Meetings](https://github.com/jupyter-widgets/team-compass/issues/1)
+## [Weekly Team Meetings](https://github.com/jupyter-widgets/team-compass/issues/19#issuecomment-1598144448)
 
 Developer Meetings take place on [zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09), every other Tuesday ([calendar](https://jupyter.org/community#calendar)) at 8:15AM Pacific Time ([your time](https://www.thetimezoneconverter.com/?t=8%3A30%20am&tz=San%20Francisco)).
 


### PR DESCRIPTION
Updating the compass to show our bi-weekly cadence and updated start time at 8.15am PT.