### PR TITLE
Fix meeting info in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A repository for team discussion, syncing, and meeting notes.
 
 ## [Weekly Team Meetings](https://github.com/jupyter-widgets/team-compass/issues/19#issuecomment-1598144448)
 
-Developer Meetings take place on [zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09), every other Tuesday ([calendar](https://jupyter.org/community#calendar)) at 8:15AM Pacific Time ([your time](https://www.thetimezoneconverter.com/?t=8%3A30%20am&tz=San%20Francisco)).
+Developer Meetings take place on [zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09), every other Friday ([calendar](https://jupyter.org/community#calendar)) at 8:00AM Pacific Time ([your time](https://dateful.com/convert/san-francisco-california?t=8am)).
 
 Minutes are taken at [Hackmd.io](https://hackmd.io/5XWHyOoLTRqyXzEHsVmxXg).
 


### PR DESCRIPTION
Update the meeting info in the README to reflect the latest meeting date on the Jupyter calendar: https://docs.jupyter.org/en/latest/community/content-community.html